### PR TITLE
Fix broken Autn.md location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ author: anuchandy
 
 To run this sample:
 
-Set the environment variable `AZURE_AUTH_LOCATION` with the full path for an auth file. See [how to create an auth file](https://github.com/Azure/azure-sdk-for-java/blob/master/AUTH.md).
+Set the environment variable `AZURE_AUTH_LOCATION` with the full path for an auth file. See [how to create an auth file](https://github.com/Azure/azure-libraries-for-java/blob/master/AUTH.md).
 
     git clone https://github.com/Azure-Samples/compute-java-manage-resources-from-vm-with-msi-in-aad-group.git
 


### PR DESCRIPTION
The url for Auth.md was broken this is because the project "azure-sdk-for-java" was renamed to "azure-libraries-for-java"